### PR TITLE
Reduce the number of warnings in IDEs

### DIFF
--- a/terra/VteObject.py
+++ b/terra/VteObject.py
@@ -88,12 +88,12 @@ class VteObjectContainer(Gtk.HBox):
     def handle_id(setter=0):
         if not hasattr(VteObjectContainer.handle_id, "counter"):
             VteObjectContainer.handle_id.counter = 0
-        if (setter != 0):
+        if setter != 0:
             ret_id = setter
         else:
             ret_id = VteObjectContainer.handle_id.counter
         VteObjectContainer.handle_id.counter = max(VteObjectContainer.handle_id.counter, setter) + 1
-        return (ret_id)
+        return ret_id
 
 
 class VteObject(Gtk.VBox):
@@ -138,31 +138,31 @@ class VteObject(Gtk.VBox):
         self.update_ui()
 
     def set_pwd(self, parent=None, pwd=None):
-        if (parent):
+        if parent:
             self.parent = parent.id
         start_directory = ConfigManager.get_conf('general', 'start_directory')
         if start_directory == '$home$':
             run_dir = os.environ['HOME']
         elif start_directory == '$pwd$':
-            if (pwd):
+            if pwd:
                 run_dir = pwd
             else:
                 pid = None
-                if (parent):
+                if parent:
                     pid = parent.pid[1]
-                elif (self.get_container()):
+                elif self.get_container():
                     pid = terra_utils.get_paned_parent(self.get_container().vte_list, self.parent).pid[1]
                 run_dir = terra_utils.get_pwd(pid)
-                if (not run_dir):
+                if not run_dir:
                     run_dir = os.getcwd()
         else:
             run_dir = start_directory
         self.pwd = run_dir
 
     def fork_process(self, progname):
-        if (not self.pwd):
+        if not self.pwd:
             self.set_pwd()
-        if (not progname):
+        if not progname:
             progname = ConfigManager.get_conf('general', 'start_shell_program')
         self.progname = progname
 
@@ -255,7 +255,7 @@ class VteObject(Gtk.VBox):
 
         if not ConfigManager.get_conf('terminal', 'use_system_font'):
             self.vte.set_font_from_string(ConfigManager.get_conf('terminal', 'font_name'))
-        if (self.pid != 0):
+        if self.pid != 0:
             self.title.set_label(terra_utils.get_running_cmd(self))
 
         self.show_all()
@@ -388,7 +388,7 @@ class VteObject(Gtk.VBox):
     def close_node(self, widget):
         parent = self.get_parent()
 
-        if (self in self.get_container().vte_list):
+        if self in self.get_container().vte_list:
             self.get_container().vte_list.remove(self)
         else:
             print("Issue Close Node")

--- a/terra/VteObject.py
+++ b/terra/VteObject.py
@@ -196,7 +196,7 @@ class VteObject(Gtk.VBox):
     def change_font_size(self, sender, factor):
         current_font = self.vte.get_font()
         current_size = current_font.get_size()
-        factor = factor + 1
+        factor += 1
         new_size = int(current_size * factor)
 
         if new_size < 2048 or new_size > 60000:

--- a/terra/VteObject.py
+++ b/terra/VteObject.py
@@ -53,6 +53,7 @@ regex_strings =[SCHEME + "//(?:" + USERPASS + "\\@)?" + HOST + PORT + URLPATH,
     "(?:mailto:)?" + USERCHARS_CLASS + "[" + USERCHARS+ ".]*\\@" + HOSTCHARS_CLASS + "+\\." + HOST,
     "(?:news:|man:|info:)[[:alnum:]\\Q^_{|}~!\"#$%&'()*+,./;:=?`\\E]+"]
 
+
 class VteObjectContainer(Gtk.HBox):
     def __init__(self, parent, bare=False, progname=None, pwd=None):
         super(VteObjectContainer, self).__init__()
@@ -94,6 +95,7 @@ class VteObjectContainer(Gtk.HBox):
         VteObjectContainer.handle_id.counter = max(VteObjectContainer.handle_id.counter, setter) + 1
         return (ret_id)
 
+
 class VteObject(Gtk.VBox):
     def __init__(self, term_id=0):
         super(Gtk.VBox, self).__init__()
@@ -116,7 +118,6 @@ class VteObject(Gtk.VBox):
         self.vscroll = Gtk.VScrollbar(self.vte.get_vadjustment())
         self.hbox.pack_start(self.vscroll, False, False, 0)
         self.pack_start(self.hbox, True, True, 0)
-
 
         for regex_string in regex_strings:
             regex_obj = GLib.Regex.new(regex_string, 0, 0)
@@ -269,7 +270,6 @@ class VteObject(Gtk.VBox):
         menu_item.connect('button-press-event', handle_event)
         menu_item.connect('activate', handle_event)
 
-
     def on_button_release(self, widget, event):
         self.get_container().active_terminal = self
 
@@ -300,7 +300,6 @@ class VteObject(Gtk.VBox):
                 self.menu_paste = Gtk.MenuItem(t("Paste"))
                 self.menu_paste.connect("activate", lambda w: self.vte.paste_clipboard())
                 self.menu.append(self.menu_paste)
-
 
             self.menu_select_all = Gtk.MenuItem(t("Select All"))
             self.menu_select_all.connect("activate", lambda w: self.vte.select_all())
@@ -479,7 +478,6 @@ class VteObject(Gtk.VBox):
         self.get_container().append_terminal(new_terminal, progname, pwd)
         parent.show_all()
         new_terminal.grab_focus()
-
 
     # direction
     # 1 = up (default)

--- a/terra/__main__.py
+++ b/terra/__main__.py
@@ -68,4 +68,3 @@ def main(project_root=ROOT):
 
 if __name__ == "__main__":
     main()
-

--- a/terra/config.py
+++ b/terra/config.py
@@ -64,8 +64,8 @@ class ConfigManager:
         try:
             value = ConfigManager.config.get(section, option)
         except ConfigParser.Error:
-            print ("[DEBUG] Config section '%s' has no option named '%s'." %
-                    (section, option))
+            print("[DEBUG] Config section '%s' has no option named '%s'." %
+                  (section, option))
             return None
 
         if option == 'select_by_word':
@@ -88,12 +88,11 @@ class ConfigManager:
         try:
             ConfigManager.config.set(section, option, str(value))
         except ConfigParser.NoSectionError:
-            print ("[DEBUG] No section '%s'."% (section))
+            print("[DEBUG] No section '%s'." % section)
             ConfigManager.config.add_section(section)
             ConfigManager.config.set(section, option, str(value))
         except ConfigParser.Error:
-            print ("[DEBUG] Config section '%s' has no option named '%s'." %
-                    (section, option))
+            print("[DEBUG] Config section '%s' has no option named '%s'." % (section, option))
             return
 
     @staticmethod
@@ -101,9 +100,9 @@ class ConfigManager:
         try:
             ConfigManager.config.remove_section(section)
         except ConfigParser.NoSectionError:
-            print ("[DEBUG] No section '%s'."% (section))
+            print("[DEBUG] No section '%s'." % section)
         except ConfigParser.Error:
-            print ("[DEBUG] No section '%s'."% (section))
+            print("[DEBUG] No section '%s'." % section)
             return
 
     @classmethod

--- a/terra/dbusservice.py
+++ b/terra/dbusservice.py
@@ -25,6 +25,7 @@ import dbus.glib
 DBUS_PATH = '/org/terraterminal/RemoteControl'
 DBUS_NAME = 'org.terraterminal.RemoteControl'
 
+
 class DbusService(dbus.service.Object):
     def __init__(self, app):
         self.app = app
@@ -35,4 +36,3 @@ class DbusService(dbus.service.Object):
     @dbus.service.method(DBUS_NAME)
     def show_hide(self):
         self.app.show_hide()
-

--- a/terra/handler.py
+++ b/terra/handler.py
@@ -8,6 +8,7 @@ from pkg_resources import DistributionNotFound, Requirement, resource_filename, 
 
 from terra import (__version__)
 
+
 class TerraHandler:
     version = __version__
     __root_path = ''

--- a/terra/handler.py
+++ b/terra/handler.py
@@ -3,7 +3,6 @@ Utilities for terra terminal.
 """
 
 import os
-import sys
 
 from pkg_resources import DistributionNotFound, Requirement, resource_filename, resource_isdir
 

--- a/terra/preferences.py
+++ b/terra/preferences.py
@@ -99,7 +99,6 @@ class Preferences:
             self.dir_custom.set_text(start_directory)
             self.dir_custom.set_sensitive(True)
 
-
         # TAB: Window
         boolean_options = [
             'use_border',
@@ -156,7 +155,6 @@ class Preferences:
 
         self.scrollback_unlimited.connect('toggled', lambda w: self.toggle_sensitive(self.scrollback_unlimited, [self.scrollback_lines]))
 
-
         # TAB: Keyboard Shortcuts
         # Store all keyboard shortcut entry boxes in array for connecting signals together.
         key_entries = [
@@ -199,7 +197,6 @@ class Preferences:
         self.restore_defaults = builder.get_object('restore_defaults')
         self.restore_defaults.connect('clicked', lambda w: self.restore_defaults_cb())
 
-
         # TAB: About
         self.logo = builder.get_object('terra_logo')
         logo_path = os.path.join(TerraHandler.get_resources_path(), 'terra.svg')
@@ -218,22 +215,18 @@ class Preferences:
         self.report_bug = builder.get_object('report_bug')
         self.report_bug.connect('clicked', lambda w: Gtk.show_uri(self.window.get_screen(), 'https://github.com/Sixdsn/terra-terminal/issues', GdkX11.x11_get_server_time(self.window.get_window())))
 
-
     def clear_key_entry(self, widget, event):
         if event.type == Gdk.EventType._2BUTTON_PRESS:
             widget.set_text("")
-
 
     def toggle_sensitive(self, source_object, target_objects):
         for target_object in target_objects:
             target_object.set_sensitive(not source_object.get_active())
 
-
     def restore_defaults_cb(self):
         for key in ConfigManager.defaults.options('shortcuts'):
             widget = getattr(self, key)
             widget.set_text(ConfigManager.defaults.get('shortcuts', key))
-
 
     def generate_key_string(self, widget, event):
         key_str = ''
@@ -254,12 +247,10 @@ class Preferences:
 
         widget.set_text(key_str)
 
-
     def show(self):
         if not self.is_running:
             self.init_ui()
         self.window.show_all()
-
 
     def on_apply_clicked(self, widget):
         # TODO: Clean!
@@ -342,7 +333,6 @@ class Preferences:
             step_time = 10
         ConfigManager.set_conf('window', 'animation_step_time', step_time)
 
-
         # TAB: Terminal
         boolean_options = [
             'use_system_font',
@@ -371,7 +361,6 @@ class Preferences:
 
         ConfigManager.set_conf('terminal', 'scrollback_lines', str(scrollback_line))
 
-
         # TAB: Shortcuts
         for key in ConfigManager.defaults.options('shortcuts'):
             widget = getattr(self, key)
@@ -386,7 +375,6 @@ class Preferences:
         self.on_apply_clicked(self.btn_ok)
         self.window.hide()
         ConfigManager.disable_losefocus_temporary = False
-
 
     def on_cancel_clicked(self, widget):
         self.is_running = False

--- a/terra/preferences.py
+++ b/terra/preferences.py
@@ -231,17 +231,17 @@ class Preferences:
     def generate_key_string(self, widget, event):
         key_str = ''
 
-        if ((Gdk.ModifierType.CONTROL_MASK & event.state) == Gdk.ModifierType.CONTROL_MASK):
-            key_str = key_str + '<Control>'
+        if (Gdk.ModifierType.CONTROL_MASK & event.state) == Gdk.ModifierType.CONTROL_MASK:
+            key_str += '<Control>'
 
-        if ((Gdk.ModifierType.MOD1_MASK & event.state) == Gdk.ModifierType.MOD1_MASK):
-            key_str = key_str + '<Alt>'
+        if (Gdk.ModifierType.MOD1_MASK & event.state) == Gdk.ModifierType.MOD1_MASK:
+            key_str += '<Alt>'
 
-        if ((Gdk.ModifierType.SHIFT_MASK & event.state) == Gdk.ModifierType.SHIFT_MASK):
-            key_str = key_str + '<Shift>'
+        if (Gdk.ModifierType.SHIFT_MASK & event.state) == Gdk.ModifierType.SHIFT_MASK:
+            key_str += '<Shift>'
 
-        if ((Gdk.ModifierType.SUPER_MASK & event.state) == Gdk.ModifierType.SUPER_MASK):
-            key_str = key_str + '<Super>'
+        if (Gdk.ModifierType.SUPER_MASK & event.state) == Gdk.ModifierType.SUPER_MASK:
+            key_str += '<Super>'
 
         key_str = key_str + Gdk.keyval_name(event.keyval)
 

--- a/terra/terminal.py
+++ b/terra/terminal.py
@@ -302,7 +302,7 @@ class TerminalWin(Gtk.Window):
             tabid = 0
             for button in self.buttonbox:
                 if button != self.radio_group_leader:
-                    section = str('layout-Tabs-%d-%d'% (self.screen_id, tabid))
+                    section = str('layout-Tabs-%d-%d' % (self.screen_id, tabid))
                     ConfigManager.set_conf(section, 'name', button.get_label())
                     tabid += 1
 
@@ -433,7 +433,7 @@ class TerminalWin(Gtk.Window):
     def add_page(self, page_name=None):
         container = None
         if page_name:
-            section=str('layout-Child-%s-0'%(page_name[len('layout-Tabs-'):]))
+            section = str('layout-Child-%s-0' % (page_name[len('layout-Tabs-'):]))
             progname = ConfigManager.get_conf(section, 'prog')
             pwd = ConfigManager.get_conf(section, 'pwd')
             container = VteObjectContainer(self, progname=progname, pwd=pwd)

--- a/terra/terminal.py
+++ b/terra/terminal.py
@@ -304,7 +304,7 @@ class TerminalWin(Gtk.Window):
                 if button != self.radio_group_leader:
                     section = str('layout-Tabs-%d-%d'% (self.screen_id, tabid))
                     ConfigManager.set_conf(section, 'name', button.get_label())
-                    tabid = tabid + 1
+                    tabid += 1
 
             tabid = 0
             for container in self.notebook.get_children():
@@ -320,7 +320,7 @@ class TerminalWin(Gtk.Window):
                     ConfigManager.set_conf(section, 'prog', child.progname)
                     ConfigManager.set_conf(section, 'pwd', child.pwd)
                     childid += 1
-                tabid = tabid + 1
+                tabid += 1
 
         ConfigManager.save_config()
 
@@ -491,7 +491,7 @@ class TerminalWin(Gtk.Window):
                     self.notebook.set_current_page(page_no)
                     self.get_active_terminal().grab_focus()
                     return
-                page_no = page_no + 1
+                page_no += 1
 
     def page_button_mouse_event(self, button, event):
         if event.button != 3:
@@ -542,7 +542,7 @@ class TerminalWin(Gtk.Window):
                     last_button = self.buttonbox.get_children()[-1]
                     last_button.set_active(True)
                     return True
-                page_no = page_no + 1
+                page_no += 1
 
     def get_screen_rectangle(self):
         display = self.screen.get_display()
@@ -852,7 +852,7 @@ class TerminalWin(Gtk.Window):
             win_rect = self.get_screen_rectangle()
         if self.get_window() != None:
             self.get_window().enable_synchronized_configure()
-        if i < step + 1:
+        if i < (step + 1):
             self.resize(win_rect.width, int(((win_rect.height/step) * i)))
             self.queue_resize()
             self.resizer.set_property('position', int(((win_rect.height/step) * i)))

--- a/terra/terminal.py
+++ b/terra/terminal.py
@@ -96,31 +96,31 @@ class TerminalWinContainer:
 
     def app_quit(self):
         for app in self.apps:
-            if (app.quit() == False):
+            if app.quit() == False:
                 return
         sys.stdout.flush()
         sys.stderr.flush()
-        if (self.is_running):
+        if self.is_running:
             Gtk.main_quit()
 
     def remove_app(self, ext):
         if ext in self.apps:
             self.apps.remove(ext)
         self.old_apps.append(ext)
-        if (len(self.apps) == 0):
+        if len(self.apps) == 0:
             self.app_quit()
 
     def create_app(self, screenName='layout'):
         monitor = terra_utils.get_screen(screenName)
-        if (screenName == 'layout'):
+        if screenName == 'layout':
             screenName = self.get_screen_name()
-        if (monitor != None):
+        if monitor != None:
             app = TerminalWin(screenName, monitor)
-            if (not self.bind_success):
+            if not self.bind_success:
                 terra_utils.cannot_bind(app)
                 raise Exception("Can't bind Global Keys")
             app.hotkey = self.hotkey
-            if (len(self.apps) == 0):
+            if len(self.apps) == 0:
                 DbusService(app)
             self.apps.append(app)
             self.screenid = max(self.screenid, int(screenName.split('-')[2])) + 1
@@ -128,7 +128,7 @@ class TerminalWinContainer:
             print("Cannot find %s"% screenName)
 
     def get_apps(self):
-        return (self.apps)
+        return self.apps
 
     def start(self):
         self.is_running = True
@@ -221,10 +221,10 @@ class TerminalWin(Gtk.Window):
         added = False
         for section in ConfigManager.get_sections():
             tabs = str('layout-Tabs-%d'% self.screen_id)
-            if (section.find(tabs) == 0 and not ConfigManager.get_conf(section, 'disabled')):
+            if section.find(tabs) == 0 and not ConfigManager.get_conf(section, 'disabled'):
                 self.add_page(page_name=str(section))
                 added = True
-        if (not added):
+        if not added:
             self.add_page()
 
         for button in self.buttonbox:
@@ -235,7 +235,7 @@ class TerminalWin(Gtk.Window):
                 break
 
     def check_visible(self):
-        if (not terra_utils.is_on_visible_screen(self)):
+        if not terra_utils.is_on_visible_screen(self):
             active_monitor = self.screen.get_monitor_workarea(self.screen.get_primary_monitor())
             terra_utils.set_new_size(self, active_monitor, self.monitor)
 
@@ -278,9 +278,9 @@ class TerminalWin(Gtk.Window):
 
     def save_conf(self, keep=True):
         tabs = str('layout-Tabs-%d'% self.screen_id)
-        if (not keep):
+        if not keep:
             for section in ConfigManager.get_sections():
-                if (section.find(tabs) == 0):
+                if section.find(tabs) == 0:
                     ConfigManager.del_conf(section)
             ConfigManager.del_conf(self.name)
         else:
@@ -328,7 +328,7 @@ class TerminalWin(Gtk.Window):
         child.pos = -1
         child.axis = axis
         child.pwd = terra_utils.get_pwd(child.pid[1])
-        if (parent):
+        if parent:
             child.pos = pos
             child.parent = parent.id
 
@@ -340,7 +340,7 @@ class TerminalWin(Gtk.Window):
         else:
             size = tree.get_allocation().height
         percentage = int(float(pos) / float(size) * float(10000))
-        return (percentage)
+        return percentage
 
     def rec_parents(self, tree, container):
         if not tree:
@@ -353,8 +353,8 @@ class TerminalWin(Gtk.Window):
         if isinstance(tree, Gtk.Paned):
             child1 = tree.get_child1()
             child2 = tree.get_child2()
-            if (child1):
-                if (isinstance(child1, Gtk.Paned)):
+            if child1:
+                if isinstance(child1, Gtk.Paned):
                     TerminalWin.rec_parents.im_func._pos = self.get_paned_pos(tree)
                     self.rec_parents(child1, container)
                 if isinstance(child1, VteObject):
@@ -368,19 +368,19 @@ class TerminalWin(Gtk.Window):
                         if len(container.vte_list) and container.vte_list[0].id == 0:
                             container.vte_list.pop(0)
                         for item in container.vte_list:
-                            if (item.parent == child1.id):
+                            if item.parent == child1.id:
                                 item.parent = 0
                         child1.id = 0
                         child1.parent = 0
                         container.vte_list.append(child1)
                         TerminalWin.rec_parents.im_func._first_child = child1
                     TerminalWin.rec_parents.im_func._parent = child1
-            if (child2):
+            if child2:
                 if isinstance(tree, Gtk.HPaned):
                     TerminalWin.rec_parents.im_func._axis = 'h'
                 else:
                     TerminalWin.rec_parents.im_func._axis = 'v'
-                if (isinstance(child2, Gtk.Paned)):
+                if isinstance(child2, Gtk.Paned):
                     TerminalWin.rec_parents.im_func._pos = self.get_paned_pos(tree)
                     self.rec_parents(child2, container)
                 if isinstance(child2, VteObject):
@@ -432,12 +432,12 @@ class TerminalWin(Gtk.Window):
 
     def add_page(self, page_name=None):
         container = None
-        if (page_name):
+        if page_name:
             section=str('layout-Child-%s-0'%(page_name[len('layout-Tabs-'):]))
             progname = ConfigManager.get_conf(section, 'prog')
             pwd = ConfigManager.get_conf(section, 'pwd')
             container = VteObjectContainer(self, progname=progname, pwd=pwd)
-        if (not container):
+        if not container:
             container = VteObjectContainer(self)
 
         self.notebook.append_page(container, None)
@@ -467,7 +467,7 @@ class TerminalWin(Gtk.Window):
         if page_name:
             for section in ConfigManager.get_sections():
                 child = str('layout-Child-%s'%(page_name[len('layout-Tabs-'):]))
-                if (section.find(child) == 0 and section[-1:] != '0'):
+                if section.find(child) == 0 and section[-1:] != '0':
                     axis = ConfigManager.get_conf(section, "axis")[0]
                     prog = ConfigManager.get_conf(section, "prog")
                     pos = ConfigManager.get_conf(section, "pos")
@@ -527,7 +527,7 @@ class TerminalWin(Gtk.Window):
 
         # don't forget "radio_group_leader"
         if button_count <= 2:
-            if (ConfigManager.get_conf('general', 'spawn_term_on_last_close')):
+            if ConfigManager.get_conf('general', 'spawn_term_on_last_close'):
                 self.add_page()
             else:
                 return self.quit()
@@ -737,8 +737,8 @@ class TerminalWin(Gtk.Window):
             page_button_list = self.buttonbox.get_children()[1:]
 
             for i in range(len(page_button_list)):
-                if (page_button_list[i].get_active() == True):
-                    if (i + 1 < len(page_button_list)):
+                if page_button_list[i].get_active() == True:
+                    if (i + 1) < len(page_button_list):
                         page_button_list[i+1].set_active(True)
                     else:
                         page_button_list[0].set_active(True)
@@ -867,7 +867,7 @@ class TerminalWin(Gtk.Window):
         if self.slide_effect_running:
             return
         event_time = self.hotkey.get_current_event_time()
-        if(self.losefocus_time and self.losefocus_time >= event_time):
+        if self.losefocus_time and self.losefocus_time >= event_time:
             return
 
         if self.get_visible():

--- a/terra/terminal.py
+++ b/terra/terminal.py
@@ -288,17 +288,17 @@ class TerminalWin(Gtk.Window):
             ConfigManager.set_conf(self.name, 'height', self.monitor.height)
             ConfigManager.set_conf(self.name, 'fullscreen', self.is_fullscreen)
 
-            #we delete all tabs first to avoid unused
-            #we delete all layouts first to avoid unused
+            # We delete all tabs first to avoid unused.
+            # We delete all layouts first to avoid unused.
             for section in ConfigManager.get_sections():
                 if (section.find("layout-Tabs-%d"% (self.screen_id)) == 0):
-                    # we won't delete those who are set as disabled
+                    # We won't delete those who are set as disabled.
                     if not ConfigManager.get_conf(section, 'disabled'):
                         ConfigManager.del_conf(section)
                 if (section.find("layout-Child-%d"% (self.screen_id)) == 0):
                     ConfigManager.del_conf(section)
 
-            #We add them all
+            # We add them all.
             tabid = 0
             for button in self.buttonbox:
                 if button != self.radio_group_leader:
@@ -332,7 +332,7 @@ class TerminalWin(Gtk.Window):
             child.pos = pos
             child.parent = parent.id
 
-    #there is a very small issue if the tabbar is visible
+    # There is a very small issue if the tabbar is visible.
     def get_paned_pos(self, tree):
         pos = tree.get_position()
         if isinstance(tree, Gtk.HPaned):
@@ -557,7 +557,7 @@ class TerminalWin(Gtk.Window):
         self.set_decorated(ConfigManager.get_conf('window', 'use_border'))
         self.set_skip_taskbar_hint(ConfigManager.get_conf('general', 'hide_from_taskbar'))
 
-        #hide/show tabbar
+        # hide/show tabbar.
         if ConfigManager.get_conf(self.name, 'hide-tab-bar'):
             self.tabbar.hide()
             self.tabbar.set_no_show_all(True)
@@ -594,13 +594,13 @@ class TerminalWin(Gtk.Window):
             if vert != None and vert <= 100:
                 height = self.monitor.height
                 vertical_position = vert * screen_rectangle.height / 100
-                #top
+                # top
                 if vertical_position - (height / 2) < 0:
                     vertical_position = screen_rectangle.y + 0
-                #bottom
+                # bottom
                 elif vertical_position + (height / 2) > screen_rectangle.height:
                     vertical_position = screen_rectangle.y + screen_rectangle.height - height
-                #center
+                # center
                 else:
                     vertical_position = screen_rectangle.y + vertical_position - (height / 2)
 
@@ -608,13 +608,13 @@ class TerminalWin(Gtk.Window):
             if horiz != None and horiz <= 100:
                 width = self.monitor.width - 1
                 horizontal_position = horiz * screen_rectangle.width / 100
-                #left
+                # left
                 if horizontal_position - (width / 2) < 0:
                     horizontal_position = screen_rectangle.x + 0
-                #right
+                # right
                 elif horizontal_position + (width / 2) > screen_rectangle.width:
                     horizontal_position = screen_rectangle.x + screen_rectangle.width - width
-                #center
+                # center
                 else:
                     horizontal_position = screen_rectangle.x + horizontal_position - (width / 2)
             self.unfullscreen()

--- a/terra/terminal.py
+++ b/terra/terminal.py
@@ -291,11 +291,11 @@ class TerminalWin(Gtk.Window):
             # We delete all tabs first to avoid unused.
             # We delete all layouts first to avoid unused.
             for section in ConfigManager.get_sections():
-                if section.find("layout-Tabs-%d"% (self.screen_id)) == 0:
+                if section.find("layout-Tabs-%d" % self.screen_id) == 0:
                     # We won't delete those who are set as disabled.
                     if not ConfigManager.get_conf(section, 'disabled'):
                         ConfigManager.del_conf(section)
-                if section.find("layout-Child-%d"% (self.screen_id)) == 0:
+                if section.find("layout-Child-%d" % self.screen_id) == 0:
                     ConfigManager.del_conf(section)
 
             # We add them all.

--- a/terra/terminal.py
+++ b/terra/terminal.py
@@ -291,11 +291,11 @@ class TerminalWin(Gtk.Window):
             # We delete all tabs first to avoid unused.
             # We delete all layouts first to avoid unused.
             for section in ConfigManager.get_sections():
-                if (section.find("layout-Tabs-%d"% (self.screen_id)) == 0):
+                if section.find("layout-Tabs-%d"% (self.screen_id)) == 0:
                     # We won't delete those who are set as disabled.
                     if not ConfigManager.get_conf(section, 'disabled'):
                         ConfigManager.del_conf(section)
-                if (section.find("layout-Child-%d"% (self.screen_id)) == 0):
+                if section.find("layout-Child-%d"% (self.screen_id)) == 0:
                     ConfigManager.del_conf(section)
 
             # We add them all.

--- a/terra/terminal.py
+++ b/terra/terminal.py
@@ -134,6 +134,7 @@ class TerminalWinContainer:
         self.is_running = True
         Gtk.main()
 
+
 class TerminalWin(Gtk.Window):
     def __init__(self, name, monitor):
         main_ui_file = os.path.join(TerraHandler.get_resources_path(), 'ui/main.ui')

--- a/terra/terra_utils.py
+++ b/terra/terra_utils.py
@@ -39,7 +39,7 @@ def my_sorted(elems):
         parent = get_paned_parent(_elems, val.parent)
         if parent and parent in _elems:
             _elems.append(val)
-            if (val in liste):
+            if val in liste:
                 liste.remove(val)
             for vale in liste:
                 if vale.parent == val.parent and vale.id <= min(liste, key=lambda a: attrgetter('id')(a)).id:
@@ -49,17 +49,17 @@ def my_sorted(elems):
 
     _elems = []
     liste = list(elems)
-    while (len(liste)):
+    while len(liste):
         liste.sort(key=lambda a: attrgetter('id')(a))
         for val in liste:
             if val.id == 0:
                 _elems.append(val)
-                if (val in liste):
+                if val in liste:
                     liste.remove(val)
                 break
             if check_heritage(val, elems, _elems, liste):
                 break
-    return (_elems)
+    return _elems
 
 def get_screen(name):
     if ConfigManager.get_conf(name, 'disabled'):
@@ -68,7 +68,7 @@ def get_screen(name):
     posy = ConfigManager.get_conf(name, 'posy')
     width = ConfigManager.get_conf(name, 'width')
     height = ConfigManager.get_conf(name, 'height')
-    if (posx == None or posy == None or width == None or height == None):
+    if posx == None or posy == None or width == None or height == None:
         posx = ConfigManager.get_conf('layout', 'posx')
         posy = ConfigManager.get_conf('layout', 'posy')
         width = ConfigManager.get_conf('layout', 'width')
@@ -97,11 +97,11 @@ def get_pwd(pid):
 
 def get_prog_values(pid, pwd):
     value = " ".join(commands.getstatusoutput("ps -p " + str(pid) + " o user=,cmd=,etime=")[1].split()).split(' ')
-    return(str("%s@%s $>%s %s"% (value[0], pwd, str(" ".join(value[1:-1])), value[-1])))
+    return str("%s@%s $>%s %s"% (value[0], pwd, str(" ".join(value[1:-1])), value[-1]))
 
 def get_running_cmd(terminal):
     pwd = get_pwd(terminal.pid[1])
-    if (not pwd):
+    if not pwd:
         pwd = os.uname()[1]
     ret = str("%s@%s $>%s"% (os.environ['USER'], pwd, "POUET"))#terminal.progname))
     try:
@@ -115,7 +115,7 @@ def get_running_cmd(terminal):
     return (ret)
 
 def set_new_size(terminal, minus, win_rect):
-    if (minus.x != terminal.get_screen_rectangle().x):
+    if minus.x != terminal.get_screen_rectangle().x:
         terminal.monitor.x = minus.x + (float(minus.width) / float(win_rect.width) * float(terminal.monitor.x - win_rect.x))
         terminal.monitor.y = minus.y + (float(minus.height) / float(win_rect.height) * float(terminal.monitor.y - win_rect.y))
         terminal.monitor.width = float(minus.width) / float(win_rect.width) * float(terminal.monitor.width)
@@ -131,11 +131,11 @@ def move_left_screen(terminal):
             screen = disp.get_screen(screen_num)
             for monitor_num in range(screen.get_n_monitors()):
                 monitor = screen.get_monitor_geometry(monitor_num)
-                if (monitor.x < minus.x and minus.x == win_rect.x):
+                if monitor.x < minus.x and minus.x == win_rect.x:
                     minus = monitor
-                elif (minus.x < monitor.x and monitor.x < win_rect.x):
+                elif minus.x < monitor.x and monitor.x < win_rect.x:
                     minus = monitor
-    if (set_new_size(terminal, minus, win_rect)):
+    if set_new_size(terminal, minus, win_rect):
         terminal.update_ui()
 
 def move_right_screen(terminal):
@@ -146,16 +146,16 @@ def move_right_screen(terminal):
             screen = disp.get_screen(screen_num)
             for monitor_num in range(screen.get_n_monitors()):
                 monitor = screen.get_monitor_geometry(monitor_num)
-                if (minus.x < monitor.x and minus.x == win_rect.x):
+                if minus.x < monitor.x and minus.x == win_rect.x:
                     minus = monitor
-                elif (minus.x > monitor.x and monitor.x > win_rect.x):
+                elif minus.x > monitor.x and monitor.x > win_rect.x:
                     minus = monitor
-    if (set_new_size(terminal, minus, win_rect)):
+    if set_new_size(terminal, minus, win_rect):
         terminal.update_ui()
 
 def is_in_screen(minus, monitor):
-    if (minus.x >= monitor.x and minus.y >= monitor.y):
-        if (minus.x + minus.width <=  monitor.x + monitor.width and minus.y + minus.height <=  monitor.y + monitor.height):
+    if minus.x >= monitor.x and minus.y >= monitor.y:
+        if minus.x + minus.width <=  monitor.x + monitor.width and minus.y + minus.height <=  monitor.y + monitor.height:
             return True
     return False
 
@@ -166,6 +166,6 @@ def is_on_visible_screen(terminal):
             screen = disp.get_screen(screen_num)
             for monitor_num in range(screen.get_n_monitors()):
                 monitor = screen.get_monitor_geometry(monitor_num)
-                if (is_in_screen(minus, monitor)):
+                if is_in_screen(minus, monitor):
                     return True
     return False

--- a/terra/terra_utils.py
+++ b/terra/terra_utils.py
@@ -103,7 +103,7 @@ def get_running_cmd(terminal):
     pwd = get_pwd(terminal.pid[1])
     if not pwd:
         pwd = os.uname()[1]
-    ret = str("%s@%s $>%s"% (os.environ['USER'], pwd, "POUET"))#terminal.progname))
+    ret = str("%s@%s $>%s"% (os.environ['USER'], pwd, "POUET"))
     try:
         pid = int(commands.getstatusoutput("ps -o pid= --ppid " + str(terminal.pid[1]))[1])
         ret = get_prog_values(pid, pwd)

--- a/terra/terra_utils.py
+++ b/terra/terra_utils.py
@@ -155,7 +155,7 @@ def move_right_screen(terminal):
 
 def is_in_screen(minus, monitor):
     if minus.x >= monitor.x and minus.y >= monitor.y:
-        if minus.x + minus.width <=  monitor.x + monitor.width and minus.y + minus.height <=  monitor.y + monitor.height:
+        if minus.x + minus.width <= monitor.x + monitor.width and minus.y + minus.height <= monitor.y + monitor.height:
             return True
     return False
 


### PR DESCRIPTION
I had several hundred warnings in my IDE, this remove a good chunk of them.

Next I'm going to update boolean conditions. But we'll need to check that PR thoroughly because the ConfigManager returns none for missing settings, and there are a lot of configurations that are checked against False. And in python `None != False` but when used in conditions both are evaluated as False.
