### PR TITLE
Fix globalhotkey bind call

### DIFF
--- a/terra/config.py
+++ b/terra/config.py
@@ -51,11 +51,6 @@ class ConfigManager:
 
     @classmethod
     def get_sections(cls):
-        # TODO: Remove! For some reason, on my setup the `sections()` method
-        # raises a "tuple assignment index out of range" exception.
-        # Reading items from the config seems to solve the issue.
-        cls.config.options('general')
-
         return cls.config.sections()
 
     @staticmethod

--- a/terra/terminal.py
+++ b/terra/terminal.py
@@ -37,7 +37,7 @@ class TerminalWinContainer:
 
         global_key_string = ConfigManager.get_conf('shortcuts', 'global_key')
         if global_key_string:
-            self.bind_success = self.hotkey.bind(global_key_string, lambda w: self.show_hide(), None)
+            self.bind_success = self.hotkey.bind(global_key_string, lambda w: self.show_hide())
         self.apps = []
         self.old_apps = []
         self.screenid = 0


### PR DESCRIPTION
I've been playing with the code, and at one point I wrote the call to the `.bind()` method without the extra `None` parameter.. and things magically started to work properly. :D

And, unlike the previous fix/hack, this one also works with my new ConfigManager, which will eventually be a simple dictionary with a few extra methods.

fixes #95 
