### PR TITLE
Remove unnecessary GtkPaned widget

### DIFF
--- a/terra/interfaces/TerminalWin.py
+++ b/terra/interfaces/TerminalWin.py
@@ -57,8 +57,9 @@ class TerminalWin(Gtk.Window):
         self.losefocus_time = 0
         self.set_has_resize_grip(False)
 
-        self.resizer = self.builder.get_object('resizer')
-        self.resizer.unparent()
+        self.main_container = self.builder.get_object('main_container')
+        """:type: Gtk.Box"""
+        self.main_container.reparent(self)
 
         self.logo = self.builder.get_object('logo')
         logo_path = os.path.join(TerraHandler.get_resources_path(), 'terra.svg')
@@ -90,7 +91,6 @@ class TerminalWin(Gtk.Window):
         self.connect('key-press-event', self.on_keypress)
         self.connect('focus-out-event', self.on_window_losefocus)
         self.connect('configure-event', self.on_window_move)
-        self.add(self.resizer)
 
         self.set_default_size(self.monitor.width, self.monitor.height)
 
@@ -441,20 +441,11 @@ class TerminalWin(Gtk.Window):
             self.move(win_rect.x, win_rect.y)
             self.fullscreen()
 
-            # hide resizer
-            if self.resizer.get_child2() is not None:
-                self.resizer.remove(self.resizer.get_child2())
-
             # hide tab bar
             if ConfigManager.get_conf(self.name, 'hide-tab-bar-fullscreen'):
                 self.tabbar.set_no_show_all(True)
                 self.tabbar.hide()
         else:
-            # show resizer
-            if self.resizer.get_child2() is None:
-                self.resizer.add2(Gtk.Box())
-                self.resizer.get_child2().show_all()
-
             vertical_position = self.monitor.y
             horizontal_position = self.monitor.x
             screen_rectangle = self.get_screen_rectangle()
@@ -726,8 +717,6 @@ class TerminalWin(Gtk.Window):
         if i < (step + 1):
             self.resize(win_rect.width, int(((win_rect.height/step) * i)))
             self.queue_resize()
-            self.resizer.set_property('position', int(((win_rect.height/step) * i)))
-            self.resizer.queue_resize()
             self.update_events()
             GObject.timeout_add(ConfigManager.get_conf('window', 'animation_step_time'), self.slide_down, i+1)
         if self.get_window() is not None:

--- a/terra/resources/main.ui
+++ b/terra/resources/main.ui
@@ -4,123 +4,50 @@
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="main_window">
     <property name="can_focus">False</property>
+    <property name="type_hint">menu</property>
     <child>
-      <object class="GtkPaned" id="resizer">
+      <object class="GtkBox" id="main_container">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox" id="main_container">
+          <object class="GtkNotebook" id="notebook">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
+            <property name="show_tabs">False</property>
+            <property name="show_border">False</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="tabbar">
+            <property name="height_request">32</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
             <child>
-              <object class="GtkNotebook" id="notebook">
+              <object class="GtkImage" id="logo">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="show_tabs">False</property>
-                <property name="show_border">False</property>
-                <child>
-                  <placeholder/>
-                </child>
-                <child type="tab">
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child type="tab">
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child type="tab">
-                  <placeholder/>
-                </child>
+                <property name="stock">gtk-missing-image</property>
               </object>
               <packing>
-                <property name="expand">True</property>
+                <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="tabbar">
-                <property name="height_request">32</property>
+              <object class="GtkBox" id="buttonbox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="margin_left">2</property>
+                <property name="border_width">2</property>
                 <child>
-                  <object class="GtkImage" id="logo">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="stock">gtk-missing-image</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="buttonbox">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">2</property>
-                    <property name="border_width">2</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="btn_new_page">
-                    <property name="use_action_appearance">False</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="relief">none</property>
-                    <child>
-                      <object class="GtkImage" id="image1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="stock">gtk-new</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="btn_fullscreen">
-                    <property name="use_action_appearance">False</property>
-                    <property name="width_request">32</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="relief">none</property>
-                    <child>
-                      <object class="GtkImage" id="image2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="stock">gtk-fullscreen</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="pack_type">end</property>
-                    <property name="position">3</property>
-                  </packing>
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -129,24 +56,55 @@
                 <property name="position">1</property>
               </packing>
             </child>
-          </object>
-          <packing>
-            <property name="resize">True</property>
-            <property name="shrink">True</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox" id="box3">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
             <child>
-              <placeholder/>
+              <object class="GtkButton" id="btn_new_page">
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="relief">none</property>
+                <child>
+                  <object class="GtkImage" id="image1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="stock">gtk-new</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_fullscreen">
+                <property name="use_action_appearance">False</property>
+                <property name="width_request">32</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="relief">none</property>
+                <child>
+                  <object class="GtkImage" id="image2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="stock">gtk-fullscreen</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">3</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="resize">False</property>
-            <property name="shrink">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
I believe the animation should still work in Gnome, but I can not test since on KDE it never worked.

From the Glade UI file I only removed the top GtkPaned widget (resizer), which caused the nesting of the file to change and I also removed an unused GtkBox widget (box3).
